### PR TITLE
ログイン画面のレイアウト崩れに対応するように修正

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -12,6 +12,8 @@ services:
       context: .
       dockerfile: ./infra/docker/php/Dockerfile
       target: ${APP_BUILD_TARGET:-development}
+    ports:
+      - "5173:5173"
     volumes:
       - type: bind
         source: ./src

--- a/src/package.json
+++ b/src/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "dev": "vite",
+        "dev": "vite --host",
         "build": "vite build"
     },
     "devDependencies": {


### PR DESCRIPTION
## 不具合
breezeのインストール後にnpm run devを実行すると、ログイン画面のレイアウトが崩れてしまっていた。

<img width="581" alt="login_layout_error" src="https://github.com/akinoringo/template1/assets/73481750/0e7780f0-817c-412b-bb89-8d74e3e0068c">

## 対応
- appのコンテナにおいて、5173port を利用するためポートを開放する設定を追加
- npm run devの実行コマンドに--hostオプションを追加

## 参考
https://zenn.dev/anchan/articles/3a82d9936fdf79